### PR TITLE
Fix authentication persistence with shared context

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,27 +4,35 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import ErrorBoundary from '../components/common/ErrorBoundary';
-import { useSupabaseAuth } from '../hooks/useSupabaseAuth';
+import { SupabaseAuthProvider, useSupabaseAuth } from '../hooks/useSupabaseAuth';
+
+// Root layout that consumes the authentication context. Having this as a
+// separate component keeps the provider mounting logic simple above.
+const RootLayout = () => {
+  const { user, isAuthenticated, logout } = useSupabaseAuth();
+
+  return (
+    <ErrorBoundary>
+      <div className="min-h-screen bg-gray-50">
+        <Header
+          user={user}
+          isAuthenticated={isAuthenticated}
+          onLogout={logout}
+        />
+        <main>
+          <Outlet />
+        </main>
+        <Footer />
+        <TanStackRouterDevtools />
+      </div>
+    </ErrorBoundary>
+  );
+};
 
 export const Route = createRootRoute({
-  component: () => {
-    const { user, isAuthenticated, logout, isLoading } = useSupabaseAuth();
-
-    return (
-      <ErrorBoundary>
-        <div className="min-h-screen bg-gray-50">
-          <Header 
-            user={user}
-            isAuthenticated={isAuthenticated}
-            onLogout={logout}
-          />
-          <main>
-            <Outlet />
-          </main>
-          <Footer />
-          <TanStackRouterDevtools />
-        </div>
-      </ErrorBoundary>
-    );
-  },
+  component: () => (
+    <SupabaseAuthProvider>
+      <RootLayout />
+    </SupabaseAuthProvider>
+  ),
 });


### PR DESCRIPTION
## Summary
- share Supabase auth state through a provider
- redirect after login once auth state updates
- wrap app with provider to keep session across pages

## Testing
- `npm run lint` *(fails: 't' is assigned a value but never used, etc.)*
- `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3c6d417cc832492fba7faa19c3f50