### PR TITLE
feat(auth): pre-check duplicate email before sign up

### DIFF
--- a/src/hooks/useSupabaseAuth.tsx
+++ b/src/hooks/useSupabaseAuth.tsx
@@ -199,6 +199,22 @@ const useSupabaseAuthInternal = () => {
   const register = async (data: RegisterData): Promise<boolean> => {
     try {
       console.log('📝 Starting registration for:', data.email);
+
+      // Quick email existence check to surface duplicate errors before signUp
+      const { data: existingProfile, error: existingError } = await supabase
+        .from('user_profiles')
+        .select('id')
+        .eq('email', data.email)
+        .maybeSingle();
+
+      if (existingError) {
+        console.error('❌ Email check failed:', existingError);
+      }
+      if (existingProfile) {
+        console.warn('⚠️ Email already registered, aborting signUp');
+        return false;
+      }
+
       const { data: authData, error: authError } = await supabase.auth.signUp({
         email: data.email,
         password: data.password,

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -27,6 +27,20 @@ export class AuthService {
         name: data.name
       });
 
+      // Pre-registration check: verify if email already exists in user_profiles
+      const { data: existingProfile, error: existingError } = await supabase
+        .from('user_profiles')
+        .select('id')
+        .eq('email', data.email)
+        .maybeSingle();
+
+      if (existingError) {
+        console.error('AuthService: Email check failed:', existingError);
+      }
+      if (existingProfile) {
+        throw new Error('Email already registered');
+      }
+
       const { data: authData, error: authError } = await supabase.auth.signUp({
         email: data.email,
         password: data.password,


### PR DESCRIPTION
## Summary
- check existing email in user_profiles before calling `signUp`
- add inline documentation about duplicate email handling

## Testing
- `npm run lint` *(fails: 64 problems (62 errors, 2 warnings))*
- `npx eslint src/services/authService.ts src/hooks/useSupabaseAuth.tsx` *(fails: Unexpected any, unused vars)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3e219664083249df71bb2954553ec