### PR TITLE
feat: manage news articles

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -1,5 +1,4 @@
-import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { useState, useEffect } from 'react';
 import { 
   Users, 
   Building, 
@@ -17,13 +16,16 @@ import {
   Filter
 } from 'lucide-react';
 import { Card, Button, Input, Modal } from '../ui';
+import NewsArticleForm from './NewsArticleForm';
+import { supabase } from '../../lib/supabase';
+import { NewsArticle } from '../../types';
 import { useSupabaseAuth } from '../../hooks/useSupabaseAuth';
 
 const AdminDashboard: React.FC = () => {
-  const { t } = useTranslation();
   const { user } = useSupabaseAuth();
   const [activeTab, setActiveTab] = useState('overview');
   const [showModal, setShowModal] = useState(false);
+  const [articles, setArticles] = useState<NewsArticle[]>([]);
 
   // Mock data - in real app this would come from API
   const stats = {
@@ -55,6 +57,33 @@ const AdminDashboard: React.FC = () => {
     { id: 'events', label: 'Events', icon: Calendar },
     { id: 'settings', label: 'Settings', icon: Settings },
   ];
+
+  const fetchArticles = async () => {
+    const { data, error } = await supabase
+      .from('news_articles')
+      .select('id, title, category, slug, is_published, published_at, image_url, excerpt')
+      .order('published_at', { ascending: false });
+    if (!error && data) {
+      setArticles(
+        data.map(a => ({
+          id: a.id,
+          title: a.title,
+          excerpt: a.excerpt,
+          category: a.category,
+          slug: a.slug,
+          image: a.image_url,
+          date: a.published_at,
+          is_published: a.is_published,
+        }))
+      );
+    }
+  };
+
+  useEffect(() => {
+    if (activeTab === 'content') {
+      fetchArticles();
+    }
+  }, [activeTab]);
 
   const renderOverview = () => (
     <div className="space-y-6">
@@ -173,6 +202,62 @@ const AdminDashboard: React.FC = () => {
           </div>
         </Card>
       </div>
+    </div>
+  );
+
+  const renderContent = () => (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-brand-primary">Articles</h3>
+        <Button icon={Plus} onClick={() => setShowModal(true)}>
+          New Article
+        </Button>
+      </div>
+      <div className="bg-white rounded-xl shadow overflow-hidden">
+        <table className="min-w-full">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Title
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Status
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {articles.map(article => (
+              <tr key={article.id} className="border-b last:border-b-0">
+                <td className="px-6 py-4">{article.title}</td>
+                <td className="px-6 py-4">
+                  <span
+                    className={`inline-block px-2 py-1 rounded-full text-xs ${
+                      article.is_published
+                        ? 'bg-green-100 text-green-700'
+                        : 'bg-yellow-100 text-yellow-700'
+                    }`}
+                  >
+                    {article.is_published ? 'Published' : 'Draft'}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <Modal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        title="Create Article"
+        size="lg"
+      >
+        <NewsArticleForm
+          onSuccess={() => {
+            setShowModal(false);
+            fetchArticles();
+          }}
+        />
+      </Modal>
     </div>
   );
 
@@ -297,13 +382,7 @@ const AdminDashboard: React.FC = () => {
                 <p className="text-gray-500">Manage business listings, approvals, and features.</p>
               </div>
             )}
-            {activeTab === 'content' && (
-              <div className="text-center py-12">
-                <FileText className="h-16 w-16 text-gray-300 mx-auto mb-4" />
-                <h3 className="text-lg font-semibold text-gray-600 mb-2">Content Management</h3>
-                <p className="text-gray-500">Manage news articles, announcements, and content.</p>
-              </div>
-            )}
+            {activeTab === 'content' && renderContent()}
             {activeTab === 'events' && (
               <div className="text-center py-12">
                 <Calendar className="h-16 w-16 text-gray-300 mx-auto mb-4" />

--- a/src/components/admin/NewsArticleForm.tsx
+++ b/src/components/admin/NewsArticleForm.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { useSupabaseAuth } from '../../hooks/useSupabaseAuth';
+import Input from '../ui/Input';
+import Button from '../ui/Button';
+
+interface Props {
+  onSuccess?: () => void;
+}
+
+const slugify = (text: string) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-');
+
+const NewsArticleForm: React.FC<Props> = ({ onSuccess }) => {
+  const { user } = useSupabaseAuth();
+  const [title, setTitle] = useState('');
+  const [excerpt, setExcerpt] = useState('');
+  const [content, setContent] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [category, setCategory] = useState('');
+  const [tags, setTags] = useState('');
+  const [isPublished, setIsPublished] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    setLoading(true);
+    setError('');
+
+    const { supabase } = await import('../../lib/supabase');
+
+    const { error: insertError } = await supabase
+      .from('news_articles')
+      .insert({
+        author_id: user.id,
+        title,
+        excerpt,
+        content,
+        image_url: imageUrl || null,
+        category,
+        slug: slugify(title),
+        tags: tags
+          .split(',')
+          .map(t => t.trim())
+          .filter(Boolean),
+        is_published: isPublished,
+        published_at: isPublished ? new Date().toISOString() : null,
+      });
+
+    if (insertError) {
+      setError(insertError.message);
+    } else {
+      setTitle('');
+      setExcerpt('');
+      setContent('');
+      setImageUrl('');
+      setCategory('');
+      setTags('');
+      setIsPublished(false);
+      onSuccess?.();
+    }
+    setLoading(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <Input label="Title" value={title} onChange={e => setTitle(e.target.value)} required />
+      <Input label="Excerpt" value={excerpt} onChange={e => setExcerpt(e.target.value)} required />
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Content</label>
+        <textarea
+          className="w-full px-4 py-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-primary/20 focus:border-brand-primary transition-colors border-gray-200"
+          rows={6}
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          required
+        />
+      </div>
+      <Input label="Image URL" value={imageUrl} onChange={e => setImageUrl(e.target.value)} />
+      <Input label="Category" value={category} onChange={e => setCategory(e.target.value)} required />
+      <Input
+        label="Tags (comma separated)"
+        value={tags}
+        onChange={e => setTags(e.target.value)}
+        helperText="e.g. shopping, dining"
+      />
+      <div className="flex items-center space-x-2">
+        <input
+          id="isPublished"
+          type="checkbox"
+          checked={isPublished}
+          onChange={e => setIsPublished(e.target.checked)}
+          className="h-4 w-4 text-brand-primary border-gray-300 rounded"
+        />
+        <label htmlFor="isPublished" className="text-sm text-gray-700">
+          Published
+        </label>
+      </div>
+      <Button type="submit" loading={loading} fullWidth>
+        Create Article
+      </Button>
+    </form>
+  );
+};
+
+export default NewsArticleForm;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,10 +49,18 @@ export interface NewsArticle {
   id: string;
   title: string;
   excerpt: string;
-  image: string;
-  date: string;
+  image?: string;
+  date?: string;
   category: string;
   slug: string;
+  /** optional fields from database */
+  content?: string;
+  image_url?: string;
+  author_id?: string;
+  author_name?: string;
+  is_published?: boolean;
+  published_at?: string;
+  tags?: string[];
 }
 
 export interface Event {

--- a/supabase/migrations/20250822033000_create_news_taxonomy.sql
+++ b/supabase/migrations/20250822033000_create_news_taxonomy.sql
@@ -1,0 +1,56 @@
+-- Create categories and tags for news articles
+CREATE TABLE IF NOT EXISTS news_categories (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  slug text UNIQUE NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS news_tags (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  slug text UNIQUE NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS news_article_tags (
+  article_id uuid REFERENCES news_articles(id) ON DELETE CASCADE,
+  tag_id uuid REFERENCES news_tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (article_id, tag_id)
+);
+
+ALTER TABLE news_articles ADD COLUMN IF NOT EXISTS category_id uuid REFERENCES news_categories(id);
+ALTER TABLE news_articles ADD COLUMN IF NOT EXISTS tags text[];
+
+CREATE INDEX IF NOT EXISTS idx_news_articles_category_id ON news_articles(category_id);
+
+-- Enable RLS
+ALTER TABLE news_categories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE news_tags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE news_article_tags ENABLE ROW LEVEL SECURITY;
+
+-- Policies for categories
+CREATE POLICY "Public read categories" ON news_categories FOR SELECT USING (true);
+CREATE POLICY "Admins manage categories" ON news_categories FOR ALL TO authenticated USING (
+  EXISTS (
+    SELECT 1 FROM user_profiles WHERE user_id = auth.uid() AND role = 'admin'
+  )
+);
+
+-- Policies for tags
+CREATE POLICY "Public read tags" ON news_tags FOR SELECT USING (true);
+CREATE POLICY "Admins manage tags" ON news_tags FOR ALL TO authenticated USING (
+  EXISTS (
+    SELECT 1 FROM user_profiles WHERE user_id = auth.uid() AND role = 'admin'
+  )
+);
+
+-- Policies for article tags
+CREATE POLICY "Public read article tags" ON news_article_tags FOR SELECT USING (true);
+CREATE POLICY "Authors manage article tags" ON news_article_tags FOR ALL TO authenticated USING (
+  EXISTS (
+    SELECT 1 FROM news_articles a
+    JOIN user_profiles u ON a.author_id = u.id
+    WHERE a.id = news_article_tags.article_id AND (u.user_id = auth.uid() OR u.role = 'admin')
+  )
+);


### PR DESCRIPTION
## Summary
- add Supabase taxonomy tables for news categories and tags
- fetch and manage news articles from the dashboard
- load article data from Supabase for list and detail views

## Testing
- `npm run lint` *(fails: 't' is assigned a value but never used, etc.)*
- `npx eslint src/components/NewsSection.tsx src/components/NewsDetail.tsx src/components/admin/AdminDashboard.tsx src/components/admin/NewsArticleForm.tsx src/types/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a7e33cac308324b6550139a4f382c3