### PR TITLE
fix: pass role metadata and handle email confirmation

### DIFF
--- a/src/hooks/useSupabaseAuth.tsx
+++ b/src/hooks/useSupabaseAuth.tsx
@@ -257,7 +257,7 @@ const useSupabaseAuthInternal = () => {
             business_website: data.businessWebsite || null,
 
             // informativo para tu UI (no seguridad)
-            account_type: data.role, // 'user' | 'business'
+            role: data.role, // 'user' | 'business'
           },
         },
       });

--- a/src/routes/auth/confirm.tsx
+++ b/src/routes/auth/confirm.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { supabase } from '../../lib/supabase';
+
+export const Route = createFileRoute('/auth/confirm')({
+  component: ConfirmPage,
+});
+
+function ConfirmPage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tokenHash = params.get('token_hash');
+    const type = (params.get('type') || 'email') as 'email' | 'signup';
+
+    const verify = async () => {
+      if (tokenHash) {
+        try {
+          await supabase.auth.verifyOtp({ token_hash: tokenHash, type });
+        } catch (err) {
+          console.error('Error verifying email:', err);
+        }
+      }
+      navigate({ to: '/auth/verify-email' });
+    };
+
+    verify();
+  }, [navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <p>Confirming your email...</p>
+    </div>
+  );
+}
+
+export default ConfirmPage;


### PR DESCRIPTION
## Summary
- pass the selected role to Supabase during registration so the trigger can store it in `user_profiles`
- add `/auth/confirm` route that verifies the email token and redirects users to the verification page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 56 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ecebf6208324921dc1dbe3cf7fb0