### PR TITLE
feat: add onboarding after email confirmation

### DIFF
--- a/src/hooks/useSupabaseAuth.tsx
+++ b/src/hooks/useSupabaseAuth.tsx
@@ -257,7 +257,7 @@ const useSupabaseAuthInternal = () => {
             business_website: data.businessWebsite || null,
 
             // informativo para tu UI (no seguridad)
-            account_type: data.role, // 'user' | 'business'
+            role: data.role, // 'user' | 'business'
           },
         },
       });

--- a/src/routes/auth/confirm.tsx
+++ b/src/routes/auth/confirm.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useEffect } from 'react';
+import { supabase } from '../../lib/supabase';
+
+export const Route = createFileRoute('/auth/confirm')({
+  component: ConfirmPage,
+});
+
+function ConfirmPage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tokenHash = params.get('token_hash');
+    const type = (params.get('type') || 'email') as 'email' | 'signup';
+
+    const verify = async () => {
+      if (!tokenHash) {
+        navigate({ to: '/auth/login' });
+        return;
+      }
+
+      try {
+        const { data, error } = await supabase.auth.verifyOtp({
+          token_hash: tokenHash,
+          type,
+        });
+
+        if (error) {
+          console.error('Error verifying email:', error);
+          navigate({ to: '/auth/login' });
+          return;
+        }
+
+        if (data.session) {
+          await supabase.auth.setSession(data.session);
+        }
+
+        navigate({ to: '/auth/onboarding' });
+      } catch (err) {
+        console.error('Error verifying email:', err);
+        navigate({ to: '/auth/login' });
+      }
+    };
+
+    verify();
+  }, [navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <p>Confirming your email...</p>
+    </div>
+  );
+}
+
+export default ConfirmPage;

--- a/src/routes/auth/onboarding.tsx
+++ b/src/routes/auth/onboarding.tsx
@@ -1,0 +1,104 @@
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
+import { useSupabaseAuth } from '../../hooks/useSupabaseAuth';
+
+export const Route = createFileRoute('/auth/onboarding')({
+  component: OnboardingPage,
+});
+
+function OnboardingPage() {
+  const { user, updateProfile, getRoleBasedRedirectPath } = useSupabaseAuth();
+  const navigate = useNavigate();
+
+  const [form, setForm] = useState({
+    name: user?.name || '',
+    phone: user?.phone || '',
+    business_name: user?.business_name || '',
+    business_description: user?.business_description || '',
+    business_address: user?.business_address || '',
+    business_website: user?.business_website || '',
+  });
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  const isBusiness = user.role === 'business';
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const ok = await updateProfile(form);
+    if (ok) {
+      const redirect = getRoleBasedRedirectPath(user.role);
+      navigate({ to: redirect as never });
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-md space-y-4 w-full max-w-md">
+        <h1 className="text-xl font-semibold text-center">Complete your profile</h1>
+        <input
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="Name"
+          className="border p-2 w-full rounded"
+        />
+        <input
+          name="phone"
+          value={form.phone}
+          onChange={handleChange}
+          placeholder="Phone"
+          className="border p-2 w-full rounded"
+        />
+        {isBusiness && (
+          <>
+            <input
+              name="business_name"
+              value={form.business_name}
+              onChange={handleChange}
+              placeholder="Business Name"
+              className="border p-2 w-full rounded"
+            />
+            <input
+              name="business_description"
+              value={form.business_description}
+              onChange={handleChange}
+              placeholder="Business Description"
+              className="border p-2 w-full rounded"
+            />
+            <input
+              name="business_address"
+              value={form.business_address}
+              onChange={handleChange}
+              placeholder="Business Address"
+              className="border p-2 w-full rounded"
+            />
+            <input
+              name="business_website"
+              value={form.business_website}
+              onChange={handleChange}
+              placeholder="Business Website"
+              className="border p-2 w-full rounded"
+            />
+          </>
+        )}
+        <button type="submit" className="w-full bg-brand-primary text-white py-2 rounded">
+          Finish
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default OnboardingPage;

--- a/supabase/migrations/20250823000000_fix_user_roles.sql
+++ b/supabase/migrations/20250823000000_fix_user_roles.sql
@@ -1,0 +1,9 @@
+-- Fix existing user roles based on metadata
+UPDATE public.user_profiles up
+SET role = CASE COALESCE(au.raw_user_meta_data->>'role', 'user')
+  WHEN 'business' THEN 'business'::user_role
+  WHEN 'admin' THEN 'admin'::user_role
+  ELSE 'user'::user_role
+END
+FROM auth.users au
+WHERE up.user_id = au.id;


### PR DESCRIPTION
## Summary
- verify email tokens, set session, and forward to onboarding
- add onboarding page to finish profile and redirect based on role
- backfill user roles from signup metadata

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 56 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ecebf6208324921dc1dbe3cf7fb0