### PR TITLE
feat: handle email confirmation with role onboarding

### DIFF
--- a/src/hooks/useSupabaseAuth.tsx
+++ b/src/hooks/useSupabaseAuth.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { supabase, UserProfile } from "../lib/supabase";
 import { UserRole } from "../types";
+import type { Session } from '@supabase/supabase-js';
 
 interface RegisterData {
   email: string;
@@ -47,7 +48,7 @@ const useSupabaseAuthInternal = () => {
   });
 
   // --- helpers ---
-  const setJwtRoleFromSession = (session: any) => {
+  const setJwtRoleFromSession = (session: Session | null) => {
     const role = (session?.user?.app_metadata?.role as string) || "";
     setAuthState((prev) => ({ ...prev, jwtRole: role }));
   };
@@ -238,11 +239,11 @@ const useSupabaseAuthInternal = () => {
 
       const emailRedirectTo =
         typeof window !== "undefined"
-          ? `${window.location.origin}/auth/verify-email`
+          ? `${window.location.origin}/auth/confirm`
           : undefined;
 
       // Enviamos SOLO user_metadata (options.data). Nada de app_metadata aquí.
-      const { data: authData, error: authError } = await supabase.auth.signUp({
+      const { error: authError } = await supabase.auth.signUp({
         email: data.email,
         password: data.password,
         options: {
@@ -290,11 +291,11 @@ const useSupabaseAuthInternal = () => {
         type: "signup",
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/verify-email`,
+          emailRedirectTo: `${window.location.origin}/auth/confirm`,
         },
       });
       return !error;
-    } catch (error) {
+    } catch {
       return false;
     }
   };

--- a/src/routes/auth/confirm.tsx
+++ b/src/routes/auth/confirm.tsx
@@ -36,7 +36,13 @@ function ConfirmPage() {
           await supabase.auth.setSession(data.session);
         }
 
-        navigate({ to: '/auth/onboarding' });
+        const role = (data.user?.user_metadata?.role as 'user' | 'business') || 'user';
+        const name =
+          (data.user?.user_metadata?.name as string) ||
+          (data.user?.user_metadata?.full_name as string) ||
+          '';
+
+        navigate({ to: '/auth/onboarding', search: { role, name } });
       } catch (err) {
         console.error('Error verifying email:', err);
         navigate({ to: '/auth/login' });

--- a/src/routes/auth/onboarding.tsx
+++ b/src/routes/auth/onboarding.tsx
@@ -1,23 +1,42 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { z } from 'zod';
 import { useSupabaseAuth } from '../../hooks/useSupabaseAuth';
+
+const searchSchema = z.object({
+  role: z.string().optional(),
+  name: z.string().optional(),
+});
 
 export const Route = createFileRoute('/auth/onboarding')({
   component: OnboardingPage,
+  validateSearch: searchSchema,
 });
 
 function OnboardingPage() {
   const { user, updateProfile, getRoleBasedRedirectPath } = useSupabaseAuth();
   const navigate = useNavigate();
+  const { role: roleFromSearch, name: nameFromSearch } = Route.useSearch();
 
   const [form, setForm] = useState({
-    name: user?.name || '',
+    name: user?.name || nameFromSearch || '',
     phone: user?.phone || '',
     business_name: user?.business_name || '',
     business_description: user?.business_description || '',
     business_address: user?.business_address || '',
     business_website: user?.business_website || '',
   });
+
+  useEffect(() => {
+    setForm({
+      name: user?.name || nameFromSearch || '',
+      phone: user?.phone || '',
+      business_name: user?.business_name || '',
+      business_description: user?.business_description || '',
+      business_address: user?.business_address || '',
+      business_website: user?.business_website || '',
+    });
+  }, [user, nameFromSearch]);
 
   if (!user) {
     return (
@@ -27,7 +46,7 @@ function OnboardingPage() {
     );
   }
 
-  const isBusiness = user.role === 'business';
+  const isBusiness = (user.role || roleFromSearch) === 'business';
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -46,7 +65,9 @@ function OnboardingPage() {
   return (
     <div className="min-h-screen flex items-center justify-center">
       <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-md space-y-4 w-full max-w-md">
-        <h1 className="text-xl font-semibold text-center">Complete your profile</h1>
+        <h1 className="text-xl font-semibold text-center">
+          {form.name ? `Welcome, ${form.name}!` : 'Complete your profile'}
+        </h1>
         <input
           name="name"
           value={form.name}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -45,7 +45,7 @@ export class AuthService {
         email: data.email,
         password: data.password,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/verify-email?email=${encodeURIComponent(data.email)}&role=${data.role}`,
+          emailRedirectTo: `${window.location.origin}/auth/confirm`,
           data: {
             full_name: data.name,
             role: data.role,
@@ -124,7 +124,7 @@ export class AuthService {
         type: 'signup',
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/verify-email`
+          emailRedirectTo: `${window.location.origin}/auth/confirm`
         }
       });
 


### PR DESCRIPTION
## Summary
- route email confirmations to `/auth/confirm`
- capture role and name from verification and send to onboarding
- allow onboarding to prefill form from query params and greet user

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/routes/auth/confirm.tsx src/routes/auth/onboarding.tsx src/hooks/useSupabaseAuth.tsx src/services/authService.ts`


------
https://chatgpt.com/codex/tasks/task_e_68abe92287548324a05569d4d42e0cc5